### PR TITLE
refactor(): use hooks for redux and reorganize redux code

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2,10 +2,9 @@ import CssBaseline from '@material-ui/core/CssBaseline'
 import { createMuiTheme } from '@material-ui/core/styles'
 import { ThemeProvider } from '@material-ui/styles'
 import React from 'react'
-import { connect } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { Redirect } from 'react-router'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
-import { setUser } from '../actions/authActions'
 import { Inputs, SignIn, SignUp } from '../containers'
 import { Header, MainNavigation, Sidebar } from './'
 import './App.css'
@@ -21,8 +20,11 @@ const theme = createMuiTheme({
   },
 })
 
-function App({ current_user }) {
-  const loggedIn = current_user && current_user.token
+function App() {
+  const loggedIn = useSelector((state) => {
+    const currentUser = state.reducers.current_user
+    return currentUser && currentUser.token
+  })
 
   return (
     <div className="App">
@@ -37,7 +39,7 @@ function App({ current_user }) {
               <SignUp />
             </Route>
             <Route path="/">
-              {loggedIn ? '' : <Redirect to="/signin" />}
+              {loggedIn ? null : <Redirect to="/signin" />}
               <Header />
               <Sidebar />
               <Switch>
@@ -54,12 +56,4 @@ function App({ current_user }) {
   )
 }
 
-const mapStateToProps = (state) => {
-  return {
-    current_user: state.reducers.current_user,
-  }
-}
-
-const mapDispatchToProps = { setUser }
-
-export default connect(mapStateToProps, mapDispatchToProps)(App)
+export default App

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,21 +1,21 @@
-import React from 'react'
-import { fade, makeStyles } from '@material-ui/core/styles'
 import AppBar from '@material-ui/core/AppBar'
-import Toolbar from '@material-ui/core/Toolbar'
-import IconButton from '@material-ui/core/IconButton'
-import Typography from '@material-ui/core/Typography'
 import Badge from '@material-ui/core/Badge'
-import MenuItem from '@material-ui/core/MenuItem'
+import IconButton from '@material-ui/core/IconButton'
 import Menu from '@material-ui/core/Menu'
+import MenuItem from '@material-ui/core/MenuItem'
+import { fade, makeStyles } from '@material-ui/core/styles'
+import Toolbar from '@material-ui/core/Toolbar'
+import Typography from '@material-ui/core/Typography'
+import MailIcon from '@material-ui/icons/Mail'
 import MenuIcon from '@material-ui/icons/Menu'
+import MoreIcon from '@material-ui/icons/MoreVert'
+import NotificationsIcon from '@material-ui/icons/Notifications'
 // import AccountCircle from '@material-ui/icons/AccountCircle';
 import PowerSettingsNewIcon from '@material-ui/icons/PowerSettingsNew'
-import MailIcon from '@material-ui/icons/Mail'
-import NotificationsIcon from '@material-ui/icons/Notifications'
-import MoreIcon from '@material-ui/icons/MoreVert'
-import { connect } from 'react-redux'
-import { logout } from '../actions/authActions'
+import React from 'react'
 import { FormattedMessage } from 'react-intl'
+import { useDispatch } from 'react-redux'
+import { logout } from '../actions/authActions'
 import { setSidebar } from '../actions/uiActions'
 
 const useStyles = makeStyles((theme) => ({
@@ -80,17 +80,19 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-function Header({ logout, setSidebar }) {
+function Header() {
   const classes = useStyles()
   const [anchorEl, setAnchorEl] = React.useState(null)
   const [mobileMoreAnchorEl, setMobileMoreAnchorEl] = React.useState(null)
+
+  const dispatch = useDispatch()
 
   const isMenuOpen = Boolean(anchorEl)
   const isMobileMenuOpen = Boolean(mobileMoreAnchorEl)
 
   const handleLogoutMenuOpen = (event) => {
     localStorage.setItem('current_user', JSON.stringify({}))
-    logout()
+    dispatch(logout())
     // setAnchorEl(event.currentTarget);
   }
 
@@ -104,7 +106,7 @@ function Header({ logout, setSidebar }) {
   }
 
   const openSidebar = () => {
-    setSidebar(true)
+    dispatch(setSidebar(true))
   }
 
   const handleMobileMenuOpen = (event) => {
@@ -204,12 +206,4 @@ function Header({ logout, setSidebar }) {
   )
 }
 
-const mapStateToProps = (state) => {
-  return {
-    current_user: state.reducers.current_user,
-  }
-}
-
-const mapDispatchToProps = { logout, setSidebar }
-
-export default connect(mapStateToProps, mapDispatchToProps)(Header)
+export default Header

--- a/src/components/InputsList.js
+++ b/src/components/InputsList.js
@@ -1,32 +1,13 @@
-import React, { useEffect } from 'react'
-import { connect } from 'react-redux'
-import { setInputs } from '../actions/inputActions'
-// import { usersPathTo } from '../utils/Api';
+import React from 'react'
 
-function InputsList({ inputs, setInputs }) {
-  useEffect(() => {
-    setInputs()
-  }, [setInputs])
-
-  return (
-    <div>
-      {inputs
-        ? inputs.map((input, index) => (
-            <div className="input" key={index}>
-              {input.name}
-            </div>
-          ))
-        : ''}
-    </div>
-  )
+function InputsList({ inputs }) {
+  return inputs
+    ? inputs.map((input, index) => (
+        <div className="input" key={index}>
+          {input.name}
+        </div>
+      ))
+    : 'No inputs'
 }
 
-const mapDispatchToProps = { setInputs }
-
-const mapStateToProps = (state) => {
-  return {
-    inputs: state.reducers.inputs,
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(InputsList)
+export default InputsList

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -8,12 +8,14 @@ import ChevronLeftIcon from '@material-ui/icons/ChevronLeft'
 import MailIcon from '@material-ui/icons/Mail'
 import InboxIcon from '@material-ui/icons/MoveToInbox'
 import React from 'react'
-import { connect } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { setSidebar } from '../actions/uiActions'
 
-function Sidebar({ sidebarOpen, setSidebar }) {
+function Sidebar() {
+  const dispatch = useDispatch()
+  const sidebarOpen = useSelector((state) => state.ui.sidebarOpen)
   const handleDrawerClose = () => {
-    setSidebar(!sidebarOpen)
+    dispatch(setSidebar(!sidebarOpen))
   }
   return (
     <Drawer variant="persistent" anchor="left" open={sidebarOpen}>
@@ -37,12 +39,4 @@ function Sidebar({ sidebarOpen, setSidebar }) {
   )
 }
 
-const mapStateToProps = (state) => {
-  return {
-    sidebarOpen: state.ui.sidebarOpen,
-  }
-}
-
-const mapDispatchToProps = { setSidebar }
-
-export default connect(mapStateToProps, mapDispatchToProps)(Sidebar)
+export default Sidebar

--- a/src/components/SignUpForm.js
+++ b/src/components/SignUpForm.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-function SignUpForm(props) {
+function SignUpForm() {
   return <div>Aqui será o SignUp form</div>
 }
 

--- a/src/containers/Inputs.js
+++ b/src/containers/Inputs.js
@@ -1,12 +1,18 @@
-import React from 'react'
-import { InputsList } from '../components'
+import React, { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { setInputs } from '../actions/inputActions'
+import InputsList from '../components/InputsList'
 
-function Inputs(props) {
-  return (
-    <div>
-      <InputsList />
-    </div>
-  )
+function Inputs() {
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    dispatch(setInputs())
+  }, [dispatch])
+
+  const inputs = useSelector((state) => state.reducers.inputs)
+
+  return <InputsList inputs={inputs} />
 }
 
 export default Inputs

--- a/src/containers/SignIn.js
+++ b/src/containers/SignIn.js
@@ -1,27 +1,22 @@
 import React from 'react'
-import { SignInForm } from '../components'
-import { Redirect } from 'react-router'
-import { connect } from 'react-redux'
-
+import { useDispatch, useSelector } from 'react-redux'
+import { Redirect } from 'react-router-dom'
 import { setUser } from '../actions/authActions'
+import SignInForm from '../components/SignInForm'
 
-function SignIn({ current_user, setUser }) {
-  const loggedIn = current_user && current_user.token
+function SignIn() {
+  const loggedIn = useSelector((state) => {
+    const currentUser = state.reducers.current_user
+    return currentUser && currentUser.token
+  })
+  const dispatch = useDispatch()
+  const dispatchSetUser = (user) => dispatch(setUser(user))
 
-  return (
-    <div>
-      {loggedIn ? <Redirect to="/inputs" /> : ''}
-      <SignInForm setUser={setUser}></SignInForm>
-    </div>
+  return loggedIn ? (
+    <Redirect to="/inputs" />
+  ) : (
+    <SignInForm setUser={dispatchSetUser} />
   )
 }
 
-const mapStateToProps = (state) => {
-  return {
-    current_user: state.reducers.current_user,
-  }
-}
-
-const mapDispatchToProps = { setUser }
-
-export default connect(mapStateToProps, mapDispatchToProps)(SignIn)
+export default SignIn

--- a/src/containers/SignUp.js
+++ b/src/containers/SignUp.js
@@ -1,26 +1,16 @@
 import React from 'react'
-import { SignUpForm } from '../components'
-import { Redirect } from 'react-router'
-import { connect } from 'react-redux'
-import { setUser } from '../actions/authActions'
+import { Redirect } from 'react-router-dom'
+import { useSelector } from 'react-redux'
+import SignUpForm from '../components/SignUpForm'
+// import { setUser } from '../actions/authActions'
 
-function SignUp({ current_user }) {
-  const loggedIn = current_user && current_user.token
+function SignUp() {
+  const loggedIn = useSelector((state) => {
+    const currentUser = state.reducers.current_user
+    return currentUser && currentUser.token
+  })
 
-  return (
-    <div>
-      {loggedIn ? <Redirect to="/inputs" /> : ''}
-      <SignUpForm></SignUpForm>
-    </div>
-  )
+  return loggedIn ? <Redirect to="/inputs" /> : <SignUpForm />
 }
 
-const mapStateToProps = (state) => {
-  return {
-    current_user: state.reducers.current_user,
-  }
-}
-
-const mapDispatchToProps = { setUser }
-
-export default connect(mapStateToProps, mapDispatchToProps)(SignUp)
+export default SignUp


### PR DESCRIPTION
# Context

Redux now comes with built in hooks that make the syntax much nicer. We no longer need to use connect and mapStateToProps etc and now we can use useSelector and useDispatch.

Also I noticed that some redux code was in the dumb components which I think should maybe stay in the containers.

# Changes

- remove uses of connect, mapStateToProps and mapDispatchToProps and convert to hook alternative
- move redux code from inputsList to inputs to keep inputsList dumb and presentational only

